### PR TITLE
Update orderid flow

### DIFF
--- a/billmate-checkout-for-woocommerce.php
+++ b/billmate-checkout-for-woocommerce.php
@@ -153,13 +153,15 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 				$raw_data = file_get_contents( 'php://input' );
 				parse_str( urldecode( $raw_data ), $result );
 				$data = json_decode( $result['data'], true );
-
+				error_log( '$data ' . var_export( $data, true ) );
 				if ( isset( $wc_order_id ) && ! empty( $wc_order_id ) && ! 'null' === $wc_order_id ) {
 					$order_id = $wc_order_id;
 					$order    = wc_get_order( $order_id );
 				} else {
+
 					$order_id = bco_get_order_id_by_temp_order_id( $data['orderid'] );
-					$order    = wc_get_order( $order_id );
+					error_log( '$order_id ' . var_export( $order_id, true ) );
+					$order = wc_get_order( $order_id );
 				}
 
 				// If the order is already completed, return.
@@ -198,7 +200,7 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 
 					if ( false !== $bco_checkout ) {
 						update_post_meta( $order_id, '_billmate_transaction_id', $bco_checkout['data']['PaymentData']['order']['number'] );
-						BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
+						// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 						bco_confirm_billmate_order( $order_id, $order, $bco_checkout ); // Confirm order.
 						bco_wc_unset_sessions(); // Unset Billmate session data.
 					}

--- a/billmate-checkout-for-woocommerce.php
+++ b/billmate-checkout-for-woocommerce.php
@@ -191,7 +191,6 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 					// Set payment method title.
 					bco_set_payment_method_title( $order_id, $bco_checkout );
 
-					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					bco_confirm_billmate_redirect_order( $order_id, $order, $data ); // Confirm.
 					bco_wc_unset_sessions(); // Unset Billmate session data.
 					wp_redirect( $order->get_checkout_order_received_url() ); // phpcs:ignore
@@ -201,7 +200,6 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 
 					if ( false !== $bco_checkout ) {
 						update_post_meta( $order_id, '_billmate_transaction_id', $bco_checkout['data']['PaymentData']['order']['number'] );
-						// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 						bco_confirm_billmate_order( $order_id, $order, $bco_checkout ); // Confirm order.
 						bco_wc_unset_sessions(); // Unset Billmate session data.
 					}

--- a/billmate-checkout-for-woocommerce.php
+++ b/billmate-checkout-for-woocommerce.php
@@ -149,20 +149,16 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 			if ( isset( $_GET['bco_confirm'] ) && isset( $_GET['wc_order_id'] ) && isset( $_GET['bco_flow']) ) { // phpcs:ignore
 				$bco_flow    = filter_input( INPUT_GET, 'bco_flow', FILTER_SANITIZE_STRING );
 				$wc_order_id = filter_input( INPUT_GET, 'wc_order_id', FILTER_SANITIZE_STRING );
-
-				$raw_data = file_get_contents( 'php://input' );
+				$raw_data    = file_get_contents( 'php://input' );
 				parse_str( urldecode( $raw_data ), $result );
 				$data = json_decode( $result['data'], true );
-				error_log( '$data ' . var_export( $data, true ) );
-				if ( isset( $wc_order_id ) && ! empty( $wc_order_id ) && ! 'null' === $wc_order_id ) {
-					$order_id = $wc_order_id;
-					$order    = wc_get_order( $order_id );
-				} else {
 
-					$order_id = bco_get_order_id_by_temp_order_id( $data['orderid'] );
-					error_log( '$order_id ' . var_export( $order_id, true ) );
-					$order = wc_get_order( $order_id );
+				if ( isset( $wc_order_id ) && ! empty( $wc_order_id ) && 'null' !== $wc_order_id ) {
+					$order_id = $wc_order_id;
+				} else {
+					$order_id = $data['orderid'];
 				}
+				$order = wc_get_order( $order_id );
 
 				// If the order is already completed, return.
 				if ( ! empty( $order->get_date_paid() ) ) {
@@ -190,7 +186,7 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 					// Set payment method title.
 					bco_set_payment_method_title( $order_id, $bco_checkout );
 
-					BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
+					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					bco_confirm_billmate_redirect_order( $order_id, $order, $data ); // Confirm.
 					bco_wc_unset_sessions(); // Unset Billmate session data.
 					wp_redirect( $order->get_checkout_order_received_url() ); // phpcs:ignore

--- a/classes/class-bco-api-callbacks.php
+++ b/classes/class-bco-api-callbacks.php
@@ -103,7 +103,6 @@ class BCO_API_Callbacks {
 					$note = sprintf( __( 'Order is still PENDING APPROVAL by Billmate. Please visit Billmate Online for the latest status on this order. Billmate Transaction id: %s', 'billmate-checkout-for-woocommerce' ), sanitize_key( $process_data['bco_number'] ) );
 					$order->add_order_note( $note );
 					update_post_meta( $order_id, '_billmate_transaction_id', $process_data['bco_number'] );
-					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					$order->update_status( 'on-hold' );
 					break;
 				case 'created':
@@ -111,7 +110,6 @@ class BCO_API_Callbacks {
 					$note = sprintf( __( 'Payment via Billmate Checkout. Transaction id: %s', 'billmate-checkout-for-woocommerce' ), sanitize_key( $process_data['bco_number'] ) );
 					$order->add_order_note( $note );
 					update_post_meta( $order_id, '_billmate_transaction_id', $process_data['bco_number'] );
-					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					$order->payment_complete( $process_data['bco_number'] );
 					break;
 				case 'paid':
@@ -119,7 +117,6 @@ class BCO_API_Callbacks {
 					$note = sprintf( __( 'Payment via Billmate Checkout. Transaction id: %s', 'billmate-checkout-for-woocommerce' ), sanitize_key( $process_data['bco_number'] ) );
 					$order->add_order_note( $note );
 					update_post_meta( $order_id, '_billmate_transaction_id', $process_data['bco_number'] );
-					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					$order->payment_complete( $process_data['bco_number'] );
 					break;
 				case 'cancelled':

--- a/classes/class-bco-api-callbacks.php
+++ b/classes/class-bco-api-callbacks.php
@@ -54,7 +54,7 @@ class BCO_API_Callbacks {
 
 		// If the callback is triggered by a new purchase, the returned orderid field is the temporary order id.
 		// If the callback is triggered by a change in the Billmate Online portal, the returned orderid field is the WC order number. Then we try to get the WC order based on the Billmate invoice number.
-		if ( substr( $data['data']['orderid'], 0, 4 ) === 'TMP:' ) {
+		if ( substr( $data['data']['orderid'], 0, 3 ) === 'tmp' ) {
 			$order_id = bco_get_order_id_by_temp_order_id( sanitize_text_field( $data['data']['orderid'] ) );
 		} else {
 			$order_id = bco_get_order_id_by_transaction_id( sanitize_text_field( $data['data']['number'] ) );

--- a/classes/class-bco-api-callbacks.php
+++ b/classes/class-bco-api-callbacks.php
@@ -103,7 +103,7 @@ class BCO_API_Callbacks {
 					$note = sprintf( __( 'Order is still PENDING APPROVAL by Billmate. Please visit Billmate Online for the latest status on this order. Billmate Transaction id: %s', 'billmate-checkout-for-woocommerce' ), sanitize_key( $process_data['bco_number'] ) );
 					$order->add_order_note( $note );
 					update_post_meta( $order_id, '_billmate_transaction_id', $process_data['bco_number'] );
-					BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
+					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					$order->update_status( 'on-hold' );
 					break;
 				case 'created':
@@ -111,7 +111,7 @@ class BCO_API_Callbacks {
 					$note = sprintf( __( 'Payment via Billmate Checkout. Transaction id: %s', 'billmate-checkout-for-woocommerce' ), sanitize_key( $process_data['bco_number'] ) );
 					$order->add_order_note( $note );
 					update_post_meta( $order_id, '_billmate_transaction_id', $process_data['bco_number'] );
-					BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
+					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					$order->payment_complete( $process_data['bco_number'] );
 					break;
 				case 'paid':
@@ -119,7 +119,7 @@ class BCO_API_Callbacks {
 					$note = sprintf( __( 'Payment via Billmate Checkout. Transaction id: %s', 'billmate-checkout-for-woocommerce' ), sanitize_key( $process_data['bco_number'] ) );
 					$order->add_order_note( $note );
 					update_post_meta( $order_id, '_billmate_transaction_id', $process_data['bco_number'] );
-					BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
+					// BCO_WC()->api->request_update_payment( $order_id ); // Update order id in Billmate.
 					$order->payment_complete( $process_data['bco_number'] );
 					break;
 				case 'cancelled':

--- a/classes/class-bco-api.php
+++ b/classes/class-bco-api.php
@@ -46,6 +46,7 @@ class BCO_API {
 	 * Update Billmate Checkout.
 	 *
 	 * @param string $bco_payment_number The Billmate payment number.
+	 * @param string $order_id The WooCommerce order ID.
 	 * @return mixed
 	 */
 	public function request_update_checkout( $bco_payment_number = null, $order_id = null ) {

--- a/classes/class-bco-api.php
+++ b/classes/class-bco-api.php
@@ -48,9 +48,9 @@ class BCO_API {
 	 * @param string $bco_payment_number The Billmate payment number.
 	 * @return mixed
 	 */
-	public function request_update_checkout( $bco_payment_number = null ) {
+	public function request_update_checkout( $bco_payment_number = null, $order_id = null ) {
 		$request  = new BCO_Request_Update_Checkout();
-		$response = $request->request( $bco_payment_number );
+		$response = $request->request( $bco_payment_number, $order_id );
 
 		return $this->check_for_api_error( $response );
 	}

--- a/classes/class-bco-gateway.php
+++ b/classes/class-bco-gateway.php
@@ -162,6 +162,7 @@ class BCO_Gateway extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 		WC()->session->set( 'bco_wc_order_id', $order_id );
+		$billmate_order = BCO_WC()->api->request_update_checkout( WC()->session->get( 'bco_wc_number' ), $order_id );
 
 		$confirmation_url = add_query_arg(
 			array(

--- a/classes/requests/checkout/post/class-bco-request-update-checkout.php
+++ b/classes/requests/checkout/post/class-bco-request-update-checkout.php
@@ -18,6 +18,7 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * Makes the request.
 	 *
 	 * @param string $bco_payment_number The Billmate payment number.
+	 * @param string $order_id The WooCommerce order ID.
 	 * @return array
 	 */
 	public function request( $bco_payment_number = null, $order_id = null ) {
@@ -39,6 +40,7 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * Gets the request body.
 	 *
 	 * @param string $bco_payment_number The Billmate payment number.
+	 * @param string $order_id The WooCommerce order ID.
 	 * @return array
 	 */
 	public function get_body( $bco_payment_number, $order_id = null ) {
@@ -61,6 +63,7 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * Gets the request args for the API call.
 	 *
 	 * @param string $bco_payment_number The Billmate payment number.
+	 * @param string $order_id The WooCommerce order ID.
 	 * @return array
 	 */
 	public function get_request_args( $bco_payment_number, $order_id = null ) {
@@ -76,6 +79,7 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * Request cart data
 	 *
 	 * @param string $bco_payment_number The Billmate payment number.
+	 * @param string $order_id The WooCommerce order ID.
 	 * @return array $data cart data.
 	 */
 	public function get_request_cart_data( $bco_payment_number, $order_id = null ) {

--- a/classes/requests/checkout/post/class-bco-request-update-checkout.php
+++ b/classes/requests/checkout/post/class-bco-request-update-checkout.php
@@ -20,9 +20,9 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * @param string $bco_payment_number The Billmate payment number.
 	 * @return array
 	 */
-	public function request( $bco_payment_number = null ) {
+	public function request( $bco_payment_number = null, $order_id = null ) {
 		$request_url  = $this->base_url;
-		$request_args = apply_filters( 'bco_update_checkout_args', $this->get_request_args( $bco_payment_number ) );
+		$request_args = apply_filters( 'bco_update_checkout_args', $this->get_request_args( $bco_payment_number, $order_id ) );
 
 		$response = wp_remote_request( $request_url, $request_args );
 		$code     = wp_remote_retrieve_response_code( $response );
@@ -41,8 +41,8 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * @param string $bco_payment_number The Billmate payment number.
 	 * @return array
 	 */
-	public function get_body( $bco_payment_number ) {
-		$data         = $this->get_request_cart_data( $bco_payment_number );
+	public function get_body( $bco_payment_number, $order_id = null ) {
+		$data         = $this->get_request_cart_data( $bco_payment_number, $order_id );
 		$request_body = array(
 			'credentials' => array(
 				'id'      => $this->id,
@@ -63,11 +63,11 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * @param string $bco_payment_number The Billmate payment number.
 	 * @return array
 	 */
-	public function get_request_args( $bco_payment_number ) {
+	public function get_request_args( $bco_payment_number, $order_id = null ) {
 		return array(
 			'headers' => $this->get_headers(),
 			'method'  => 'POST',
-			'body'    => wp_json_encode( $this->get_body( $bco_payment_number ) ),
+			'body'    => wp_json_encode( $this->get_body( $bco_payment_number, $order_id ) ),
 			'timeout' => apply_filters( 'bco_set_timeout', 10 ),
 		);
 	}
@@ -78,7 +78,7 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 	 * @param string $bco_payment_number The Billmate payment number.
 	 * @return array $data cart data.
 	 */
-	public function get_request_cart_data( $bco_payment_number ) {
+	public function get_request_cart_data( $bco_payment_number, $order_id = null ) {
 		$data = array(
 			'Articles'    => BCO_Cart_Articles_Helper::get_articles(),
 			'Cart'        =>
@@ -90,6 +90,9 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 				'number' => $bco_payment_number,
 			),
 		);
+		if ( ! empty( $order_id ) ) {
+			$data['PaymentData']['orderid'] = $order_id;
+		}
 		return $data;
 	}
 }

--- a/includes/bco-functions.php
+++ b/includes/bco-functions.php
@@ -41,7 +41,7 @@ function bco_init_checkout() {
 			$billmate_order = BCO_WC()->api->request_update_checkout( WC()->session->get( 'bco_wc_number' ) );
 			if ( ! $billmate_order ) {
 				// If update order failed try to create new order.
-				WC()->session->set( 'bco_wc_temp_order_id', 'tmp:' . md5( uniqid( wp_rand(), true ) ) );
+				WC()->session->set( 'bco_wc_temp_order_id', 'tmp' . md5( uniqid( wp_rand(), true ) ) );
 				$billmate_order = BCO_WC()->api->request_init_checkout();
 				if ( ! $billmate_order ) {
 					// If failed then bail.
@@ -58,7 +58,7 @@ function bco_init_checkout() {
 
 		} else {
 			// Initialize payment.
-			WC()->session->set( 'bco_wc_temp_order_id', 'tmp:' . md5( uniqid( wp_rand(), true ) ) );
+			WC()->session->set( 'bco_wc_temp_order_id', 'tmp' . md5( uniqid( wp_rand(), true ) ) );
 			$billmate_order = BCO_WC()->api->request_init_checkout();
 			if ( ! $billmate_order ) {
 				return;

--- a/includes/bco-functions.php
+++ b/includes/bco-functions.php
@@ -41,7 +41,7 @@ function bco_init_checkout() {
 			$billmate_order = BCO_WC()->api->request_update_checkout( WC()->session->get( 'bco_wc_number' ) );
 			if ( ! $billmate_order ) {
 				// If update order failed try to create new order.
-				WC()->session->set( 'bco_wc_temp_order_id', 'TMP:' . md5( uniqid( wp_rand(), true ) ) );
+				WC()->session->set( 'bco_wc_temp_order_id', 'tmp:' . md5( uniqid( wp_rand(), true ) ) );
 				$billmate_order = BCO_WC()->api->request_init_checkout();
 				if ( ! $billmate_order ) {
 					// If failed then bail.
@@ -58,7 +58,7 @@ function bco_init_checkout() {
 
 		} else {
 			// Initialize payment.
-			WC()->session->set( 'bco_wc_temp_order_id', 'TMP:' . md5( uniqid( wp_rand(), true ) ) );
+			WC()->session->set( 'bco_wc_temp_order_id', 'tmp:' . md5( uniqid( wp_rand(), true ) ) );
 			$billmate_order = BCO_WC()->api->request_init_checkout();
 			if ( ! $billmate_order ) {
 				return;


### PR DESCRIPTION
Updates the orderid from WooCommerce to Billmate as soon as the order is created in WooCommerce. This happens on the purchase_initialized JS event.