### PR TITLE
WC order number instead of order id

### DIFF
--- a/billmate-checkout-for-woocommerce.php
+++ b/billmate-checkout-for-woocommerce.php
@@ -170,7 +170,7 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 					if ( substr( $data['orderid'], 0, 3 ) === 'tmp' ) {
 						$order_id = bco_get_order_id_by_temp_order_id( sanitize_text_field( $data['orderid'] ) );
 					} else {
-						$order_id = $data['orderid'];
+						$order_id = bco_get_order_id_by_billmate_saved_woo_order_no( $data['orderid'] );
 					}
 				}
 				$order = wc_get_order( $order_id );

--- a/classes/class-bco-gateway.php
+++ b/classes/class-bco-gateway.php
@@ -164,6 +164,7 @@ class BCO_Gateway extends WC_Payment_Gateway {
 		$order = wc_get_order( $order_id );
 		WC()->session->set( 'bco_wc_order_id', $order_id );
 		$billmate_order = BCO_WC()->api->request_update_checkout( WC()->session->get( 'bco_wc_number' ), $order_id );
+		update_post_meta( $order_id, '_billmate_saved_woo_order_no', $order->get_order_number() );
 
 		$confirmation_url = add_query_arg(
 			array(

--- a/classes/requests/checkout/post/class-bco-request-update-checkout.php
+++ b/classes/requests/checkout/post/class-bco-request-update-checkout.php
@@ -96,7 +96,8 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 			),
 		);
 		if ( ! empty( $order_id ) ) {
-			$data['PaymentData']['orderid'] = $order_id;
+			$order                          = wc_get_order( $order_id );
+			$data['PaymentData']['orderid'] = $order->get_order_number();
 		}
 		return $data;
 	}

--- a/includes/bco-functions.php
+++ b/includes/bco-functions.php
@@ -339,6 +339,37 @@ function bco_get_order_id_by_transaction_id( $transaction_id ) {
 }
 
 /**
+ * Finds an Order ID based on a transaction ID (the Billmate invoice number).
+ *
+ * @param string $billmate_orderid Billmate orderid _billmate_saved_woo_order_no in WC order ($order->get_order_number).
+ * @return int The ID of an order, or 0 if the order could not be found.
+ */
+function bco_get_order_id_by_billmate_saved_woo_order_no( $billmate_orderid ) {
+	$query_args = array(
+		'fields'      => 'ids',
+		'post_type'   => wc_get_order_types(),
+		'post_status' => array_keys( wc_get_order_statuses() ),
+		'meta_key'    => '_billmate_saved_woo_order_no', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'meta_value'  => sanitize_text_field( wp_unslash( $billmate_orderid ) ), // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'date_query'  => array(
+			array(
+				'after' => '2 day ago',
+			),
+		),
+	);
+
+	$orders = get_posts( $query_args );
+
+	if ( $orders ) {
+		$order_id = $orders[0];
+	} else {
+		$order_id = 0;
+	}
+
+	return $order_id;
+}
+
+/**
  * Adds the invoice fee to WC order if this is a invoice payment and invoice fee is set in plugin settings.
  *
  * @param object $order WooCommerce order.


### PR DESCRIPTION
Add support for sending WooCommerce order number (instead of order_id) to Billmate.