### PR TITLE
Avoid division by zero in discount calculation - fixes #122

### DIFF
--- a/src/classes/requests/helpers/cart/class-bco-cart-articles-helper.php
+++ b/src/classes/requests/helpers/cart/class-bco-cart-articles-helper.php
@@ -195,6 +195,11 @@ class BCO_Cart_Articles_Helper {
 		$article_price = wc_get_price_excluding_tax( $cart_item['data'] );
 		$line_total    = $cart_item['line_total'];
 
+		// No discount for already 0 value articles.
+		if ( 0.0 === round( $article_price, 2 ) ) {
+			return 0;
+		}
+
 		if ( ( $article_price * $cart_item['quantity'] ) !== $line_total ) {
 			return round( ( 1 - ( $line_total / ( $article_price * $cart_item['quantity'] ) ) ) * 100 );
 		} else {


### PR DESCRIPTION
Causes json formatting to crash.
No need to calculate the discount if article price is 0.