### PR TITLE
Hotfix - fixes #122

### DIFF
--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_CHECKOUT_VERSION', '1.0.3' );
+define( 'BILLMATE_CHECKOUT_VERSION', '1.0.4' );
 define( 'BILLMATE_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_ENV', 'https://api.billmate.se' );

--- a/src/classes/requests/helpers/cart/class-bco-cart-articles-helper.php
+++ b/src/classes/requests/helpers/cart/class-bco-cart-articles-helper.php
@@ -195,6 +195,11 @@ class BCO_Cart_Articles_Helper {
 		$article_price = wc_get_price_excluding_tax( $cart_item['data'] );
 		$line_total    = $cart_item['line_total'];
 
+		// No discount for already 0 value articles.
+		if ( 0.0 === round( $article_price, 2 ) ) {
+			return 0;
+		}
+
 		if ( ( $article_price * $cart_item['quantity'] ) !== $line_total ) {
 			return round( ( 1 - ( $line_total / ( $article_price * $cart_item['quantity'] ) ) ) * 100 );
 		} else {

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -51,6 +51,9 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-checkout-for-woocommerce](https://github.com/Billmate/billmate-checkout-for-woocommerce).
 
 == Changelog ==
+= 2021.03.04    - version 1.0.4 =
+* Fix           - Avoid division by zero problem in discount calculation. Fixes compatibility issue with WPC Product Bundles for WooCommerce.
+
 = 2021.02.23    - version 1.0.3 =
 * Fix           - Adds support for Approved and Denied callback order status from Billmate when order had status Pending previously.
 


### PR DESCRIPTION
* Fix - Avoid division by zero problem in discount calculation. Fixes compatibility issue with WPC Product Bundles for WooCommerce.
* Prepared version number and readme for version 1.0.4.