### PR TITLE
Version 1.3.0

### DIFF
--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 		 *
 		 * @return void
 		 */
-		private function __wakeup() {
+		public function __wakeup() {
 			wc_doing_it_wrong( __FUNCTION__, __( 'Nope' ), '1.0' );
 		}
 

--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -12,7 +12,7 @@
  * Domain Path:     /languages
  *
  * WC requires at least: 4.0.0
- * WC tested up to: 5.3.0
+ * WC tested up to: 5.4.1
  *
  * Copyright:       © 2020-2021 Billmate in collaboration with Krokedil.
  * License:         GNU General Public License v3.0
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_CHECKOUT_VERSION', '1.2.0' );
+define( 'BILLMATE_CHECKOUT_VERSION', '1.3.0' );
 define( 'BILLMATE_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_ENV', 'https://api.billmate.se' );

--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -70,7 +70,7 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 		 *
 		 * @return void
 		 */
-		private function __clone() {
+		public function __clone() {
 			wc_doing_it_wrong( __FUNCTION__, __( 'Nope' ), '1.0' );
 		}
 		/**

--- a/src/classes/class-bco-api-callbacks.php
+++ b/src/classes/class-bco-api-callbacks.php
@@ -136,6 +136,8 @@ class BCO_API_Callbacks {
 					update_post_meta( $order_id, '_billmate_transaction_id', $process_data['bco_number'] );
 					update_post_meta( $order_id, '_billmate_payment_denied', 'yes' );
 					$order->update_status( 'failed', $note );
+					// Trigger bco_callback_denied_order action so we can cancel the order in BO from Billmate Order Management plugin.
+					do_action( 'bco_callback_denied_order', $order_id );
 					break;
 				case 'cancelled':
 					// Translators: Billmate transaction id.

--- a/src/classes/requests/helpers/order/class-bco-order-customer-helper.php
+++ b/src/classes/requests/helpers/order/class-bco-order-customer-helper.php
@@ -131,9 +131,7 @@ class BCO_Order_Customer_Helper {
 	 * @return string
 	 */
 	public static function get_billing_country( $order ) {
-		$countries     = include WC()->plugin_path() . '/i18n/countries.php';
-		$order_country = $order->get_billing_country();
-		return $countries[ $order_country ];
+		return $order->get_billing_country();
 	}
 
 	/**
@@ -235,8 +233,6 @@ class BCO_Order_Customer_Helper {
 	 * @return string
 	 */
 	public static function get_shipping_country( $order ) {
-		$countries     = include WC()->plugin_path() . '/i18n/countries.php';
-		$order_country = $order->get_shipping_country();
-		return $countries[ $order_country ];
+		return $order->get_shipping_country();
 	}
 }

--- a/src/includes/bco-functions.php
+++ b/src/includes/bco-functions.php
@@ -380,7 +380,9 @@ function bco_maybe_add_invoice_fee( $order ) {
 	if ( '1' === get_post_meta( $order_id, '_billmate_payment_method_id', true ) ) {
 		$billmate_settings = get_option( 'woocommerce_bco_settings' );
 		$invoice_fee       = isset( $billmate_settings['invoice_fee'] ) ? str_replace( ',', '.', $billmate_settings['invoice_fee'] ) : '';
-		if ( ! empty( $invoice_fee ) && is_numeric( $invoice_fee ) ) {
+
+		// Check that we have an invoice fee and that no transaction id is set yet (to avoid that we add invoice fee multiple times).
+		if ( ! empty( $invoice_fee ) && is_numeric( $invoice_fee ) && empty( $order->get_transaction_id() ) ) {
 
 			$fee = new WC_Order_Item_Fee();
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 5.0
 Tested up to: 5.7.2
 Requires PHP: 5.6
 WC requires at least: 4.0.0
-WC tested up to: 5.3.0
+WC tested up to: 5.4.1
 Stable tag: __STABLE_TAG__
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -51,6 +51,10 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-checkout-for-woocommerce](https://github.com/Billmate/billmate-checkout-for-woocommerce).
 
 == Changelog ==
+= 2021.07.05    - version 1.3.0 =
+* Tweak         - Add hook bco_callback_denied_order, to be able to automatically cancel order in Billmate if a denied order callback is triggered from Billmate.
+* Fix           - Only add invoice fee to order if no transaction_id exists. Avoids multiple invoice fee lines.
+
 = 2021.05.19    - version 1.2.0 =
 * Feature       - Add feature for disabling address update in WooCommerce checkout form. By using bco_populate_address_fields filter, Billmate address data will not override logged in Woocommerce customer data. 
 * Feature       - Checkout page template: Changes in template file markup.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -54,6 +54,7 @@ The easiest way to report a bug is to email us at [support@billmate.se](mailto:s
 = 2021.07.05    - version 1.3.0 =
 * Tweak         - Add hook bco_callback_denied_order, to be able to automatically cancel order in Billmate if a denied order callback is triggered from Billmate.
 * Fix           - Only add invoice fee to order if no transaction_id exists. Avoids multiple invoice fee lines.
+* Fix           - PHP8 warning fix.
 
 = 2021.05.19    - version 1.2.0 =
 * Feature       - Add feature for disabling address update in WooCommerce checkout form. By using bco_populate_address_fields filter, Billmate address data will not override logged in Woocommerce customer data. 


### PR DESCRIPTION
* Tweak - Add hook bco_callback_denied_order, to be able to automatically cancel order in Billmate if a denied order callback is triggered from Billmate.
* Fix - Only add invoice fee to order if no transaction_id exists. Avoids multiple invoice fee lines.
* Fix - PHP8 warning fix.