### PR TITLE
Version 1.4.0

### DIFF
--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -12,7 +12,7 @@
  * Domain Path:     /languages
  *
  * WC requires at least: 4.0.0
- * WC tested up to: 5.5.2
+ * WC tested up to: 5.6.0
  *
  * Copyright:       © 2020-2021 Billmate in collaboration with Krokedil.
  * License:         GNU General Public License v3.0
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_CHECKOUT_VERSION', '1.3.0' );
+define( 'BILLMATE_CHECKOUT_VERSION', '1.4.0' );
 define( 'BILLMATE_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_ENV', 'https://api.billmate.se' );

--- a/src/classes/requests/helpers/cart/class-bco-cart-payment-data-helper.php
+++ b/src/classes/requests/helpers/cart/class-bco-cart-payment-data-helper.php
@@ -56,8 +56,20 @@ class BCO_Cart_Payment_Data_Helper {
 	 * @return string
 	 */
 	public static function get_language() {
-		// Swedish is the only supported language at the moment.
-		return 'sv';
+		$locale = substr( get_locale(), 0, 2 );
+
+		// If the site language is Englis - let's return en.
+		if ( 'en' === $locale ) {
+			return 'en';
+		}
+
+		// If SEK is the selected currency  - let's use sv.
+		if ( 'SEK' === get_woocommerce_currency() ) {
+			return 'sv';
+		}
+
+		// Otherwise - let's use en.
+		return 'en';
 	}
 
 	/**

--- a/src/includes/bco-functions.php
+++ b/src/includes/bco-functions.php
@@ -35,7 +35,7 @@ function bco_init_checkout() {
 		WC()->cart->calculate_fees();
 		WC()->cart->calculate_shipping();
 		WC()->cart->calculate_totals();
-		if ( WC()->session->get( 'bco_wc_hash' ) ) {
+		if ( WC()->session->get( 'bco_wc_hash' ) && get_woocommerce_currency() === WC()->session->get( 'bco_currency' ) ) {
 
 			// Try to update the order, if it fails try to create new order.
 			$billmate_order = BCO_WC()->api->request_update_checkout( WC()->session->get( 'bco_wc_number' ) );
@@ -49,6 +49,7 @@ function bco_init_checkout() {
 				}
 				WC()->session->set( 'bco_wc_number', $billmate_order['data']['number'] );
 				WC()->session->set( 'bco_wc_checkout_url', $billmate_order['data']['url'] . '?activateJsEvents=1' );
+				WC()->session->set( 'bco_currency', get_woocommerce_currency() );
 				set_checkout_hash( $billmate_order['data']['url'] );
 				return $billmate_order;
 			}
@@ -65,6 +66,7 @@ function bco_init_checkout() {
 			}
 			WC()->session->set( 'bco_wc_number', $billmate_order['data']['number'] );
 			WC()->session->set( 'bco_wc_checkout_url', $billmate_order['data']['url'] . '?activateJsEvents=1' );
+			WC()->session->set( 'bco_currency', get_woocommerce_currency() );
 			set_checkout_hash( $billmate_order['data']['url'] );
 
 			return $billmate_order;
@@ -80,6 +82,7 @@ function bco_init_checkout() {
 
 		WC()->session->set( 'bco_wc_order_id', $billmate_order['data']['orderid'] );
 		WC()->session->set( 'bco_wc_checkout_url', $billmate_order['data']['url'] );
+		WC()->session->set( 'bco_currency', get_woocommerce_currency() );
 		set_checkout_hash( $billmate_order['data']['url'] );
 
 		return $billmate_order;
@@ -162,6 +165,7 @@ function bco_wc_unset_sessions() {
 	WC()->session->__unset( 'bco_wc_checkout_url' );
 	WC()->session->__unset( 'bco_wc_number' );
 	WC()->session->__unset( 'bco_wc_temp_order_id' );
+	WC()->session->__unset( 'bco_currency' );
 }
 
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,10 +2,10 @@
 Contributors: Billmate, Krokedil, NiklasHogefjord
 Tags: woocommerce, billmate, ecommerce, e-commerce, checkout, swish, invoice, part-payment, installment, partpayment, card, mastercard, visa, trustly, swish
 Requires at least: 5.0
-Tested up to: 5.8
+Tested up to: 5.8.1
 Requires PHP: 5.6
 WC requires at least: 4.0.0
-WC tested up to: 5.5.2
+WC tested up to: 5.6.0
 Stable tag: __STABLE_TAG__
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -51,6 +51,12 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-checkout-for-woocommerce](https://github.com/Billmate/billmate-checkout-for-woocommerce).
 
 == Changelog ==
+= 2021.09.13    - version 1.4.0 =
+* Feature       - Add support for selling to Nordic countries (DKK, EUR & NOK). Specific agreement with Billmate needed. Logic for sending correct customer country and currency needs to be handled by WooCommerce.
+* Feature       - Add support for English locale in Billmate Checkout (logic based on selected WP locale).
+* Tweak         - Improved PHP8 support.
+* Fix           - Change customer country to be sent as ISO 3166-1 2-character in updatePayment requests to Billmate.
+
 = 2021.08.17    - version 1.3.0 =
 * Tweak         - Add hook bco_callback_denied_order, to be able to automatically cancel order in Billmate if a denied order callback is triggered from Billmate.
 * Fix           - Only add invoice fee to order if no transaction_id exists. Avoids multiple invoice fee lines.


### PR DESCRIPTION
* Feature - Add support for selling to Nordic countries (DKK, EUR & NOK). Specific agreement with Billmate needed. Logic for sending correct customer country and currency needs to be handled by WooCommerce.
* Feature - Add support for English locale in Billmate Checkout (logic based on selected WP locale).
* Tweak - Improved PHP8 support.
* Fix - Change customer country to be sent as ISO 3166-1 2-character in updatePayment requests to Billmate.