### PR TITLE
Version 1.6.5

### DIFF
--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_CHECKOUT_VERSION', '1.6.4' );
+define( 'BILLMATE_CHECKOUT_VERSION', '1.6.5' );
 define( 'BILLMATE_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_ENV', 'https://api.billmate.se' );

--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -12,9 +12,9 @@
  * Domain Path:     /languages
  *
  * WC requires at least: 5.0.0
- * WC tested up to: 8.3.1
+ * WC tested up to: 8.5.1
  *
- * Copyright:       © 2020-2023 Billmate in collaboration with Krokedil.
+ * Copyright:       © 2020-2024 Billmate in collaboration with Krokedil.
  * License:         GNU General Public License v3.0
  * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_CHECKOUT_VERSION', '1.6.3' );
+define( 'BILLMATE_CHECKOUT_VERSION', '1.6.4' );
 define( 'BILLMATE_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_ENV', 'https://api.billmate.se' );

--- a/src/classes/class-bco-templates.php
+++ b/src/classes/class-bco-templates.php
@@ -20,9 +20,9 @@ class BCO_Templates {
 	 */
 	protected static $instance;
 
-    public $enabled;
-    public $show_order_notes;
-    public $checkout_layout;
+	public $enabled;
+	public $show_order_notes;
+	public $checkout_layout;
 
 	/**
 	 * Returns the *Singleton* instance of this class.
@@ -60,6 +60,7 @@ class BCO_Templates {
 		add_action( 'bco_wc_before_checkout_form', 'woocommerce_checkout_login_form', 10 );
 		add_action( 'bco_wc_before_checkout_form', 'woocommerce_checkout_coupon_form', 20 );
 		add_action( 'bco_wc_after_order_review', 'bco_wc_show_another_gateway_button', 20 );
+		add_action( 'bco_wc_before_billmate_checkout_form', array( $this, 'add_smart_coupons_fields' ) );
 
 		// Hook to check if we should hide the Order notes field in checkout.
 		add_action( 'template_redirect', array( $this, 'maybe_hide_order_notes_field' ), 1000 );
@@ -275,6 +276,16 @@ class BCO_Templates {
 			}
 		}
 		return $class;
+	}
+
+	/**
+	 * Add action hooks required by Smart Coupons.
+	 *
+	 * @return void
+	 */
+	public function add_smart_coupons_fields() {
+		// Required by smart coupons to show the "Send Coupons to..." form.
+		do_action( 'woocommerce_checkout_after_customer_details' );
 	}
 }
 

--- a/src/classes/requests/helpers/cart/class-bco-cart-articles-helper.php
+++ b/src/classes/requests/helpers/cart/class-bco-cart-articles-helper.php
@@ -96,12 +96,20 @@ class BCO_Cart_Articles_Helper {
 	 * @return array
 	 */
 	public static function get_smart_coupon_line( $coupon ) {
+		$apply_before_tax = 'yes' === get_option( 'woocommerce_smart_coupon_apply_before_tax', 'no' );
+		if ( wc_tax_enabled() && $apply_before_tax ) {
+			// The discount is applied directly to the cart item. Send gift card amount as zero for bookkeeping.
+			$coupon_amount = 0;
+		} else {
+			$coupon_amount = $coupon->get_amount() * -1;
+		}
+
 		return array(
 			'artnr'      => $coupon->get_id(),
 			'title'      => __( 'Gift Card', 'billmate-checkout-for-woocommerce' ),
 			'quantity'   => 1,
-			'aprice'     => round( ( $coupon->get_amount() * -1 ) * 100 ),
-			'withouttax' => round( ( $coupon->get_amount() * -1 ) * 100 ),
+			'aprice'     => round( ( $coupon_amount ) * 100 ),
+			'withouttax' => round( ( $coupon_amount ) * 100 ),
 			'taxrate'    => 0,
 			'discount'   => 0,
 		);

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -51,6 +51,10 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-checkout-for-woocommerce](https://github.com/Billmate/billmate-checkout-for-woocommerce).
 
 == Changelog ==
+= 2024.03.11    - version 1.6.5 =
+* Fix           - The Smart Coupons' "Send Coupons to..." should now be displayed on the checkout page.
+* Fix           - Fixed tax issues related to Smart Coupons when certain settings in the coupons' plugin were enabled.
+
 = 2024.01.16    - version 1.6.4 =
 * Fix           - Adds logic to avoid confirm process to run in multiple instances if customer reloads confirm/thank you page.
 * Fix           - Fixed PHP 8 deprecation warnings.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 5.0
 Tested up to: 6.4.2
 Requires PHP: 7.4
 WC requires at least: 5.0.0
-WC tested up to: 8.3.1
+WC tested up to: 8.5.1
 Stable tag: __STABLE_TAG__
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -51,6 +51,10 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-checkout-for-woocommerce](https://github.com/Billmate/billmate-checkout-for-woocommerce).
 
 == Changelog ==
+= 2024.01.16    - version 1.6.4 =
+* Fix           - Adds logic to avoid confirm process to run in multiple instances if customer reloads confirm/thank you page.
+* Fix           - Fixed PHP 8 deprecation warnings.
+
 = 2023.12.12    - version 1.6.3 =
 * Tweak         - Improved logging around confirm payment step for easier troubleshooting.
 * Tweak         - Improved credentials check in callback handler.


### PR DESCRIPTION
* Fix           - The Smart Coupons' "Send Coupons to..." should now be displayed on the checkout page.
* Fix           - Fixed tax issues related to Smart Coupons when certain settings in the coupons' plugin were enabled.