### PR TITLE
Version 1.7.0

### DIFF
--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_CHECKOUT_VERSION', '1.6.5' );
+define( 'BILLMATE_CHECKOUT_VERSION', '1.6.6' );
 define( 'BILLMATE_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_ENV', 'https://api.billmate.se' );

--- a/src/billmate-checkout-for-woocommerce.php
+++ b/src/billmate-checkout-for-woocommerce.php
@@ -12,7 +12,7 @@
  * Domain Path:     /languages
  *
  * WC requires at least: 5.0.0
- * WC tested up to: 8.5.1
+ * WC tested up to: 9.4.3
  *
  * Copyright:       © 2020-2024 Billmate in collaboration with Krokedil.
  * License:         GNU General Public License v3.0
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_CHECKOUT_VERSION', '1.6.6' );
+define( 'BILLMATE_CHECKOUT_VERSION', '1.7.0' );
 define( 'BILLMATE_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_CHECKOUT_ENV', 'https://api.billmate.se' );
@@ -165,7 +165,6 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 
 			// Includes.
 			include_once BILLMATE_CHECKOUT_PATH . '/includes/bco-functions.php';
-
 		}
 
 		/**
@@ -193,7 +192,6 @@ if ( ! class_exists( 'Billmate_Checkout_For_WooCommerce' ) ) {
 			$section_slug = 'bco';
 			return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $section_slug );
 		}
-
 	}
 	Billmate_Checkout_For_WooCommerce::get_instance();
 

--- a/src/classes/class-bco-ajax.php
+++ b/src/classes/class-bco-ajax.php
@@ -133,7 +133,6 @@ class BCO_AJAX extends WC_AJAX {
 		// Everything is okay if we get here. Send empty success and kill wp.
 		wp_send_json_success();
 		wp_die();
-
 	}
 
 	/**
@@ -260,7 +259,7 @@ class BCO_AJAX extends WC_AJAX {
 		// Set payment method title.
 		bco_set_payment_method_title( $order_id, $bco_checkout );
 
-		bco_maybe_add_invoice_fee( $order ); // Maybe set invoice fee in WC order.
+		// Confirm Billmate order.
 		bco_confirm_billmate_order( $order_id, $bco_checkout );
 
 		if ( false !== $bco_checkout ) {

--- a/src/classes/class-bco-confirmation.php
+++ b/src/classes/class-bco-confirmation.php
@@ -59,12 +59,10 @@ class BCO_Confirmation {
 
 			if ( isset( $wc_order_id ) && ! empty( $wc_order_id ) && 'null' !== $wc_order_id ) {
 				$order_id = $wc_order_id;
-			} else {
-				if ( substr( $data['orderid'], 0, 3 ) === 'tmp' ) {
+			} elseif ( substr( $data['orderid'], 0, 3 ) === 'tmp' ) {
 					$order_id = bco_get_order_id_by_temp_order_id( sanitize_text_field( $data['orderid'] ) );
-				} else {
-					$order_id = bco_get_order_id_by_billmate_saved_woo_order_no( $data['orderid'] );
-				}
+			} else {
+				$order_id = bco_get_order_id_by_billmate_saved_woo_order_no( $data['orderid'] );
 			}
 
 			BCO_Logger::log( 'Confirm order triggered. WC order ID: ' . wp_json_encode( $order_id ) );
@@ -114,8 +112,6 @@ class BCO_Confirmation {
 				// Set payment method title.
 				bco_set_payment_method_title( $order_id, $bco_checkout );
 
-				bco_maybe_add_invoice_fee( $order ); // Maybe set invoice fee in WC order.
-
 				bco_confirm_billmate_redirect_order( $order_id, $order, $data ); // Confirm.
 				bco_wc_unset_sessions(); // Unset Qvickly session data.
                 wp_redirect( $order->get_checkout_order_received_url() ); // phpcs:ignore
@@ -129,8 +125,6 @@ class BCO_Confirmation {
 					// Set payment method title.
 					bco_set_payment_method_title( $order_id, $bco_checkout );
 
-					bco_maybe_add_invoice_fee( $order ); // Maybe set invoice fee in WC order.
-
 					bco_confirm_billmate_order( $order_id, $bco_checkout ); // Confirm order.
 					bco_wc_unset_sessions(); // Unset Qvickly session data.
 				}
@@ -139,7 +133,5 @@ class BCO_Confirmation {
 			}
 		}
 	}
-
-
 }
 BCO_Confirmation::get_instance();

--- a/src/classes/class-bco-templates.php
+++ b/src/classes/class-bco-templates.php
@@ -60,7 +60,6 @@ class BCO_Templates {
 		add_action( 'bco_wc_before_checkout_form', 'woocommerce_checkout_login_form', 10 );
 		add_action( 'bco_wc_before_checkout_form', 'woocommerce_checkout_coupon_form', 20 );
 		add_action( 'bco_wc_after_order_review', 'bco_wc_show_another_gateway_button', 20 );
-		add_action( 'bco_wc_before_billmate_checkout_form', array( $this, 'add_smart_coupons_fields' ) );
 
 		// Hook to check if we should hide the Order notes field in checkout.
 		add_action( 'template_redirect', array( $this, 'maybe_hide_order_notes_field' ), 1000 );
@@ -276,16 +275,6 @@ class BCO_Templates {
 			}
 		}
 		return $class;
-	}
-
-	/**
-	 * Add action hooks required by Smart Coupons.
-	 *
-	 * @return void
-	 */
-	public function add_smart_coupons_fields() {
-		// Required by smart coupons to show the "Send Coupons to..." form.
-		do_action( 'woocommerce_checkout_after_customer_details' );
 	}
 }
 

--- a/src/classes/requests/checkout/post/class-bco-request-init-checkout.php
+++ b/src/classes/requests/checkout/post/class-bco-request-init-checkout.php
@@ -97,7 +97,7 @@ class BCO_Request_Init_Checkout extends BCO_Request {
 			'Articles'     => BCO_Order_Articles_Helper::get_articles( $order ),
 			'Cart'         =>
 			array(
-				'Handling' => BCO_Order_Cart_Helper::get_order_cart_handling( $order ),
+				// 'Handling' => BCO_Order_Cart_Helper::get_order_cart_handling( $order ),
 				'Shipping' => BCO_Order_Cart_Helper::get_order_cart_shipping( $order ),
 				'Total'    => BCO_Order_Cart_Helper::get_order_cart_total( $order ),
 			),
@@ -126,7 +126,7 @@ class BCO_Request_Init_Checkout extends BCO_Request {
 			'Articles'     => BCO_Cart_Articles_Helper::get_articles(),
 			'Cart'         =>
 			array(
-				'Handling' => BCO_Cart_Cart_Helper::get_handling(),
+				// 'Handling' => BCO_Cart_Cart_Helper::get_handling(),
 				'Shipping' => BCO_Cart_Cart_Helper::get_shipping(),
 				'Total'    => BCO_Cart_Cart_Helper::get_total(),
 			),

--- a/src/classes/requests/checkout/post/class-bco-request-update-checkout.php
+++ b/src/classes/requests/checkout/post/class-bco-request-update-checkout.php
@@ -89,7 +89,7 @@ class BCO_Request_Update_Checkout extends BCO_Request {
 			array(
 				'Total'    => BCO_Cart_Cart_Helper::get_total(),
 				'Shipping' => BCO_Cart_Cart_Helper::get_shipping(),
-				'Handling' => BCO_Cart_Cart_Helper::get_handling(),
+				// 'Handling' => BCO_Cart_Cart_Helper::get_handling(),
 			),
 			'PaymentData' => array(
 				'number' => $bco_payment_number,

--- a/src/classes/requests/helpers/cart/class-bco-cart-cart-helper.php
+++ b/src/classes/requests/helpers/cart/class-bco-cart-cart-helper.php
@@ -45,10 +45,10 @@ class BCO_Cart_Cart_Helper {
 	 */
 	public static function get_total() {
 		return array(
-			'withouttax' => self::get_total_without_tax() + self::get_handling_without_tax(),
-			'tax'        => self::get_total_tax() + self::get_handling_tax(),
+			'withouttax' => self::get_total_without_tax(),
+			'tax'        => self::get_total_tax(),
 			'rounding'   => 0,
-			'withtax'    => self::get_total_with_tax() + self::get_handling_without_tax() + self::get_handling_tax(),
+			'withtax'    => self::get_total_with_tax(),
 		);
 	}
 
@@ -188,5 +188,4 @@ class BCO_Cart_Cart_Helper {
 	public static function get_total_with_tax() {
 		return round( WC()->cart->total * 100 );
 	}
-
 }

--- a/src/includes/bco-form-fields.php
+++ b/src/includes/bco-form-fields.php
@@ -44,7 +44,7 @@ $settings = array(
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable logging', 'billmate-checkout-for-woocommerce' ),
 		'default'     => 'no',
-		'description' => sprintf( __( 'Log ' . $this->method_title . ' events in <code>%s</code>', 'billmate-checkout-for-woocommerce' ), wc_get_log_file_path( 'billmate_checkout' ) ), // phpcs:ignore
+		'description' => __( 'Log Qvickly events to the plugin log file.', 'billmate-checkout-for-woocommerce' ),
 	),
 	'checkout_layout'                    => array(
 		'title'       => __( 'Checkout layout', 'billmate-checkout-for-woocommerce' ),

--- a/src/includes/bco-form-fields.php
+++ b/src/includes/bco-form-fields.php
@@ -93,21 +93,6 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'invoice_fee'                        => array(
-		'title'       => __( 'Invoice fee', 'billmate-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Add Invoice fee excluding tax. Leave blank to deactivate this feature.', 'billmate-checkout-for-woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-	),
-	'invoice_fee_tax'                    => array(
-		'title'       => __( 'Tax class for invoice fee', 'billmate-checkout-for-woocommerce' ),
-		'type'        => 'select',
-		'options'     => wc_get_product_tax_class_options(),
-		'description' => __( 'Select the tax class that should be used for the invoice fee.', 'billmate-checkout-for-woocommerce' ),
-		'default'     => 'false',
-		'desc_tip'    => false,
-	),
 	// Monthly cost display.
 	'montly_cost_display'                => array(
 		'title' => __( 'Monthly cost display', 'billmate-checkout-for-woocommerce' ),

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -51,6 +51,9 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-checkout-for-woocommerce](https://github.com/Billmate/billmate-checkout-for-woocommerce).
 
 == Changelog ==
+= 2024.03.11    - version 1.6.6 =
+* Tweak         - Remove redundant action hook to prevent hook from being triggered more than once.
+
 = 2024.03.11    - version 1.6.5 =
 * Fix           - The Smart Coupons' "Send Coupons to..." should now be displayed on the checkout page.
 * Fix           - Fixed tax issues related to Smart Coupons when certain settings in the coupons' plugin were enabled.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,10 +2,10 @@
 Contributors: Billmate, Krokedil, NiklasHogefjord
 Tags: woocommerce, billmate, ecommerce, e-commerce, checkout, swish, invoice, part-payment, installment, partpayment, card, mastercard, visa, trustly, swish
 Requires at least: 5.0
-Tested up to: 6.4.2
+Tested up to: 6.7.1
 Requires PHP: 7.4
 WC requires at least: 5.0.0
-WC tested up to: 8.5.1
+WC tested up to: 9.4.3
 Stable tag: __STABLE_TAG__
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -51,6 +51,10 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-checkout-for-woocommerce](https://github.com/Billmate/billmate-checkout-for-woocommerce).
 
 == Changelog ==
+= 2024.12.16    - version 1.7.0 =
+* Tweak         - Remove setting and logic for adding invoice fee to invoice payments. Qvickly is moving away from this logic.
+* Fix           - Remove wc_get_log_file_path helper function to display path to plugin log file. Deprecated by Woo.
+
 = 2024.03.11    - version 1.6.6 =
 * Tweak         - Remove redundant action hook to prevent hook from being triggered more than once.
 


### PR DESCRIPTION
* Tweak - Remove setting and logic for adding invoice fee to invoice payments. Qvickly is moving away from this logic.
* Fix - Remove wc_get_log_file_path helper function to display path to plugin log file. Deprecated by Woo.